### PR TITLE
Pbc exchange

### DIFF
--- a/fidimag/micro/energy.py
+++ b/fidimag/micro/energy.py
@@ -34,7 +34,8 @@ class Energy(object):
         self.xperiodic = mesh.xperiodic
         self.yperiodic = mesh.yperiodic
         self.zperiodic = mesh.zperiodic
-
+        
+        self.connectivity = mesh.connectivity
     def compute_field(self, t=0):
 
         return 0

--- a/fidimag/micro/exchange.py
+++ b/fidimag/micro/exchange.py
@@ -23,11 +23,7 @@ class UniformExchange(Energy):
                                                 self.dx,
                                                 self.dy,
                                                 self.dz,
-                                                self.nx,
-                                                self.ny,
-                                                self.nz,
-                                                self.xperiodic,
-                                                self.yperiodic,
-                                                self.yperiodic)
+                                                self.nxyz,
+                                                self.connectivity)
 
         return self.field

--- a/fidimag/micro/lib/exch.c
+++ b/fidimag/micro/lib/exch.c
@@ -1,122 +1,47 @@
 #include "micro_clib.h"
 
 void compute_exch_field_micro(double *m, double *field, double *energy,
-		double *Ms_inv, double A, double dx, double dy, double dz, int nx,
-		int ny, int nz, int xperiodic, int yperiodic, int zperiodic) {
-
-    int nxy = nx*ny;
-    int nxyz = nxy*nz;
+			      double *Ms_inv, double A, double dx, double dy, double dz, int nxyz, int *ngbs) {
 
 	double ax = 2 * A / (dx * dx), ay = 2 * A / (dy * dy), az = 2 * A / (dz * dz);
 
 	#pragma omp parallel for
-    for (int k = 0; k < nz; k++) {
-        for (int j = 0; j < ny; j++) {
-	       for (int i = 0; i < nx; i++) { 
 
-				int index = nxy * k + nx * j + i;
-				int indexm = 3*index;
+ 
+	for (int i = 0; i < nxyz; i++) {		
+	  double fx = 0, fy = 0, fz = 0;
+	  int idm = 0;
+	  int idn = 6 * i; // index for the neighbours
+	  if (Ms_inv[i] == 0.0){
+	      field[3*i] = 0;
+	      field[3*i+1] = 0;
+	      field[3*i+2] = 0;
+	      continue;
+	  }
+	  for (int j = 0; j < 6; j++) {
+	    if (ngbs[idn + j] >= 0) {
+	      idm = 3 * ngbs[idn + j];
+	      // if (Ms_inv[i] > 0){
+		fx += ax * (m[idm] - m[3*i]);
+		fy += ax * (m[idm+1] - m[3*i+1]);
+		fz += ax * (m[idm+2] - m[3*i+2]);
 
-                if (Ms_inv[index] == 0.0){
-                    field[3*index] = 0;
-                    field[3*index+1] = 0;
-                    field[3*index+2] = 0;
-                    energy[index] = 0;
-                    continue;
-                }
+		fx += ay * (m[idm] - m[3*i]);
+		fy += ay * (m[idm+1] - m[3*i+1]);
+		fz += ay * (m[idm+2] - m[3*i+2]);
 
-                int id=0, idm=0;
-				double fx = 0, fy = 0, fz = 0;
+		fx += az * (m[idm] - m[3*i]);
+		fy += az * (m[idm+1] - m[3*i+1]);
+		fz += az * (m[idm+2] - m[3*i+2]);
+		//}
+	     }
 
-                if (k > 0 || zperiodic ) {
-                    id = index - nxy;
-                    if (k == 0){
-                        id += nxyz;
-                    }
-                    idm = 3*id;
-					//in general this is unnecessary for normal LLG equation,
-					//but for LLbar this is very important.
-					if (Ms_inv[id] > 0) {
-						fx += az * (m[idm] - m[indexm]);
-						fy += az * (m[idm+1] - m[indexm+1]);
-						fz += az * (m[idm+2] - m[indexm+2]);
-					}
-				}
-
-                if (j > 0 || yperiodic) {
-                    id = index - nx;
-                    if (j==0) {
-                        id += nxy;
-                    }
-                    idm = 3*id;
-					if (Ms_inv[id] > 0) {
-						fx += ay * (m[idm] - m[indexm]);
-						fy += ay * (m[idm+1] - m[indexm+1]);
-						fz += ay * (m[idm+2] - m[indexm+2]);
-					}
-				}
-
-                if (i > 0 || xperiodic) {
-                    id = index - 1;
-                    if (i==0) {
-                        id += nx;
-                    }
-                    idm = 3*id;
-					if (Ms_inv[id] > 0) {
-						fx += ax * (m[idm] - m[indexm]);
-						fy += ax * (m[idm+1] - m[indexm+1]);
-						fz += ax * (m[idm+2] - m[indexm+2]);
-					}
-				}
-
-                if (i < nx - 1 || xperiodic) {
-                    id = index + 1;
-                    if (i == nx-1){
-                        id -= nx;
-                    }
-                    idm = 3*id;
-					if (Ms_inv[id] > 0) {
-						fx += ax * (m[idm] - m[indexm]);
-						fy += ax * (m[idm+1] - m[indexm+1]);
-						fz += ax * (m[idm+2] - m[indexm+2]);
-					}
-				}
-
-                if (j < ny - 1 || yperiodic) {
-                    id = index + nx;
-                    if (j == ny-1){
-                        id -= nxy;
-                    }
-                    idm = 3*id;
-					if (Ms_inv[id] > 0) {
-						fx += ay * (m[idm] - m[indexm]);
-						fy += ay * (m[idm+1] - m[indexm+1]);
-						fz += ay * (m[idm+2] - m[indexm+2]);
-					}
-				}
-
-                if (k < nz - 1 || zperiodic ) {
-                    id = index + nxy;
-                    if (k == nz-1){
-                        k -= nxyz;
-                    }
-                    idm = 3*id;
-					if (Ms_inv[id] > 0) {
-						fx += az * (m[idm] - m[indexm]);
-						fy += az * (m[idm+1] - m[indexm+1]);
-						fz += az * (m[idm+2] - m[indexm+2]);
-					}
-				}
-
-                energy[index] = -0.5*(fx*m[indexm]+fy*m[indexm+1]+fz*m[indexm+2]);
-                
-                // Note: both here and Dx don't have factor of 2.
-                field[indexm] = fx*Ms_inv[index]*MU0_INV;
-                field[indexm + 1] = fy*Ms_inv[index]*MU0_INV;
-                field[indexm + 2] = fz*Ms_inv[index]*MU0_INV;
-
-			}
-		}
+       
+	  }
+      energy[i] = -0.5*(fx*m[3*i]+fy*m[3*i+1]+fz*m[3*i+2]);
+      printf("energy=%f", &energy[i]);
+      field[3*i] = fx*Ms_inv[i]*MU0_INV;
+      field[3*i + 1] = fy*Ms_inv[i]*MU0_INV;
+      field[3*i + 2] = fz*Ms_inv[i]*MU0_INV;
 	}
 }
-

--- a/fidimag/micro/lib/exch.c
+++ b/fidimag/micro/lib/exch.c
@@ -1,47 +1,63 @@
 #include "micro_clib.h"
 
 void compute_exch_field_micro(double *m, double *field, double *energy,
-			      double *Ms_inv, double A, double dx, double dy, double dz, int nxyz, int *ngbs) {
+			      double *Ms_inv, double A, double dx, double dy, double dz,
+                  int nxyz, int *ngbs) {
 
-	double ax = 2 * A / (dx * dx), ay = 2 * A / (dy * dy), az = 2 * A / (dz * dz);
+	double ax = 2 * A / (dx * dx);
+    double ay = 2 * A / (dy * dy);
+    double az = 2 * A / (dz * dz);
 
 	#pragma omp parallel for
+	for (int i = 0; i < nxyz; i++) {
+	    double fx = 0, fy = 0, fz = 0;
+	    int idm = 0;
+	    int idn = 6 * i; // index for the neighbours
 
- 
-	for (int i = 0; i < nxyz; i++) {		
-	  double fx = 0, fy = 0, fz = 0;
-	  int idm = 0;
-	  int idn = 6 * i; // index for the neighbours
-	  if (Ms_inv[i] == 0.0){
-	      field[3*i] = 0;
-	      field[3*i+1] = 0;
-	      field[3*i+2] = 0;
-	      continue;
-	  }
-	  for (int j = 0; j < 6; j++) {
-	    if (ngbs[idn + j] >= 0) {
-	      idm = 3 * ngbs[idn + j];
-	      // if (Ms_inv[i] > 0){
-		fx += ax * (m[idm] - m[3*i]);
-		fy += ax * (m[idm+1] - m[3*i+1]);
-		fz += ax * (m[idm+2] - m[3*i+2]);
+	    if (Ms_inv[i] == 0.0){
+	        field[3 * i] = 0;
+	        field[3 * i + 1] = 0;
+	        field[3 * i + 2] = 0;
+	        continue;
+	    }
 
-		fx += ay * (m[idm] - m[3*i]);
-		fy += ay * (m[idm+1] - m[3*i+1]);
-		fz += ay * (m[idm+2] - m[3*i+2]);
+        for (int j = 0; j < 6; j++) {
+	        if (ngbs[idn + j] >= 0) {
+	            idm = 3 * ngbs[idn + j];
+                // if (Ms_inv[i] > 0){
 
-		fx += az * (m[idm] - m[3*i]);
-		fy += az * (m[idm+1] - m[3*i+1]);
-		fz += az * (m[idm+2] - m[3*i+2]);
-		//}
-	     }
+                if (j == 0 || j == 1) {
+                    fx += ax * (m[idm]     - m[3 * i]);
+                    fy += ax * (m[idm + 1] - m[3 * i + 1]);
+                    fz += ax * (m[idm + 2] - m[3 * i + 2]);
+                }
 
-       
-	  }
-      energy[i] = -0.5*(fx*m[3*i]+fy*m[3*i+1]+fz*m[3*i+2]);
-      printf("energy=%f", &energy[i]);
-      field[3*i] = fx*Ms_inv[i]*MU0_INV;
-      field[3*i + 1] = fy*Ms_inv[i]*MU0_INV;
-      field[3*i + 2] = fz*Ms_inv[i]*MU0_INV;
-	}
+                else if (j == 2 || j == 3) {
+                    fx += ay * (m[idm]     - m[3  * i]);
+                    fy += ay * (m[idm + 1] - m[3 * i + 1]);
+                    fz += ay * (m[idm + 2] - m[3 * i + 2]);
+                }
+
+                else if (j == 4 || j == 5) {
+                    fx += az * (m[idm]     - m[3 * i]);
+                    fy += az * (m[idm + 1] - m[3 * i + 1]);
+                    fz += az * (m[idm + 2] - m[3 * i + 2]);
+                }
+
+                else {
+                    printf("Passing");
+                    continue; }
+                //}
+            }
+        }
+
+        energy[i] = -0.5 * (fx * m[3 * i] + fy * m[3 * i + 1]
+                            + fz * m[3 * i + 2]);
+
+        // printf("energy=%f", energy[i]);
+
+        field[3 * i]     = fx * Ms_inv[i] * MU0_INV;
+        field[3 * i + 1] = fy * Ms_inv[i] * MU0_INV;
+        field[3 * i + 2] = fz * Ms_inv[i] * MU0_INV;
+    }
 }

--- a/fidimag/micro/lib/exch.c
+++ b/fidimag/micro/lib/exch.c
@@ -80,7 +80,7 @@ void compute_exch_field_micro(double *m, double *field, double *energy,
 	#pragma omp parallel for
 	for (int i = 0; i < nxyz; i++) {
 	    double fx = 0, fy = 0, fz = 0;
-	    int idm = 0;     // Index for the magnetisation matrix
+	    int idnm = 0;     // Index for the magnetisation matrix
 	    int idn = 6 * i; // index for the neighbours
 
         /* Set a zero field for sites without magnetic material */
@@ -127,7 +127,6 @@ void compute_exch_field_micro(double *m, double *field, double *energy,
                     fz += az * (m[idnm + 2] - m[3 * i + 2]);
                 }
                 else {
-                    printf("Passing");
                     continue; }
                 //}
             }

--- a/fidimag/micro/lib/exch.c
+++ b/fidimag/micro/lib/exch.c
@@ -98,37 +98,44 @@ void compute_exch_field_micro(double *m, double *field, double *energy,
                 /* Magnetisation of the neighbouring spin since ngbs gives
                  * the neighbour's index */
 	            idnm = 3 * ngbs[idn + j];
-                // if (Ms_inv[i] > 0){
+
+                /* Check that the magnetisation of the neighbouring spin
+                 * is larger than zero */
+                if (Ms_inv[ngbs[idn + j]] > 0){
                 
-                /* Neighbours in the -x and +x directions 
-                 * giving: ( m[i-x] - m[i] ) + ( m[i+x] - m[i] )
-                 * when ngbs[idn + j] > 0 for j = 0 and j=1
-                 * but there is a problem if, for example, there is no
-                 * neighbour at -x (j=0) in the 0th node (no PBCs),
-                 * thus, the second derivative would only be avaluated as:
-                 *      (1 / dx * dx) * ( m[i+x] - m[i] )
-                 * which is a wrong approximation (!) --> ASK about this
-                 */
-                if (j == 0 || j == 1) {
-                    fx += ax * (m[idnm]     - m[3 * i]);
-                    fy += ax * (m[idnm + 1] - m[3 * i + 1]);
-                    fz += ax * (m[idnm + 2] - m[3 * i + 2]);
+                    /* Neighbours in the -x and +x directions 
+                     * giving: ( m[i-x] - m[i] ) + ( m[i+x] - m[i] )
+                     * when ngbs[idn + j] > 0 for j = 0 and j=1
+                     * If, for example, there is no
+                     * neighbour at -x (j=0) in the 0th node (no PBCs),
+                     * the second derivative would only be avaluated as:
+                     *      (1 / dx * dx) * ( m[i+x] - m[i] )
+                     * which, according to 
+                     * [M.J. Donahue and D.G. Porter; Physica B, 343, 177-183 (2004)]
+                     * when performing the integration of the energy, we still
+                     * have error of the order O(dx^2)
+                     * This same applies for the other directions
+                     */
+                    if (j == 0 || j == 1) {
+                        fx += ax * (m[idnm]     - m[3 * i]);
+                        fy += ax * (m[idnm + 1] - m[3 * i + 1]);
+                        fz += ax * (m[idnm + 2] - m[3 * i + 2]);
+                    }
+                    /* Neighbours in the -y and +y directions */
+                    else if (j == 2 || j == 3) {
+                        fx += ay * (m[idnm]     - m[3  * i]);
+                        fy += ay * (m[idnm + 1] - m[3 * i + 1]);
+                        fz += ay * (m[idnm + 2] - m[3 * i + 2]);
+                    }
+                    /* Neighbours in the -z and +z directions */
+                    else if (j == 4 || j == 5) {
+                        fx += az * (m[idnm]     - m[3 * i]);
+                        fy += az * (m[idnm + 1] - m[3 * i + 1]);
+                        fz += az * (m[idnm + 2] - m[3 * i + 2]);
+                    }
+                    else {
+                        continue; }
                 }
-                /* Neighbours in the -y and +y directions */
-                else if (j == 2 || j == 3) {
-                    fx += ay * (m[idnm]     - m[3  * i]);
-                    fy += ay * (m[idnm + 1] - m[3 * i + 1]);
-                    fz += ay * (m[idnm + 2] - m[3 * i + 2]);
-                }
-                /* Neighbours in the -z and +z directions */
-                else if (j == 4 || j == 5) {
-                    fx += az * (m[idnm]     - m[3 * i]);
-                    fy += az * (m[idnm + 1] - m[3 * i + 1]);
-                    fz += az * (m[idnm + 2] - m[3 * i + 2]);
-                }
-                else {
-                    continue; }
-                //}
             }
         }
 

--- a/fidimag/micro/lib/exch.c
+++ b/fidimag/micro/lib/exch.c
@@ -4,46 +4,128 @@ void compute_exch_field_micro(double *m, double *field, double *energy,
 			      double *Ms_inv, double A, double dx, double dy, double dz,
                   int nxyz, int *ngbs) {
 
+    /* Compute the micromagnetic exchange field and energy using the
+     * matrix of neighbouring spins and a second order approximation
+     * for the derivative
+     *
+     * Ms_inv     :: Array with the (1 / Ms) values for every mesh node.
+     *               The values are zero for points with Ms = 0 (no material)
+     *  
+     * A          :: Exchange constant
+     * 
+     * dx, dy, dz :: Mesh spacings in the corresponding directions
+     * 
+     * nxyz       :: Number of mesh nodes
+     *
+     * ngbs       :: The array of neighbouring spins, which has (6 * nxyz)
+     *               entries. Specifically, it contains the indexes of 
+     *               the neighbours of every mesh node, in the following order:
+     *                      -x, +x, -y, +y, -z, +z
+     *  
+     *               Thus, the array is like:
+     *              | 0-x, 0+x, 0-y, 0+y, 0-z, 0+z, 1-x, 1+x, 1-y, ...  |
+     *                i=0                           i=1                ...
+     *                           
+     *              where  0-y  is the index of the neighbour of the 0th spin,
+     *              in the -y direction, for example. The index value for a
+     *              neighbour where Ms = 0, is evaluated as -1. The array
+     *              automatically gives periodic boundaries.
+     *
+     *              A basic example is a 3 x 3 two dimensional mesh with PBCs
+     *              in the X and Y direction:
+     *
+     *                                  +-----------+
+     *                                  | 6 | 7 | 8 |
+     *                                  +-----------+
+     *                                  | 3 | 4 | 5 |
+     *                                  +-----------+
+     *                                  | 0 | 1 | 2 |
+     *                                  +-----------+
+     *
+     *              so, the first 6 entries (neighbours of the 0th mesh node)
+     *              of the array would be: [ 2  1  6  3 -1 -1 ... ]
+     *              (-1 since there is no material in +-z, and a '2' first,
+     *              since it is the left neighbour which is the PBC in x, etc..)
+     *
+     *  For the exchange computation, the field is defined as:
+     *          H_ex = (2 * A / (mu0 * Ms)) * nabla^2 (mx, my, mz) 
+     *
+     *  Therefore, for the i-th mesh node (spin), we approximate the
+     *  derivatives as:
+     *          nabla^2 mx = (1 / dx^2) * ( m[i-x] - 2 * m[i] + m[i+x] ) + 
+     *                       (1 / dy^2) * ( m[i-y] - 2 * m[i] + m[i+y] ) +  
+     *                       (1 / dz^2) * ( m[i-z] - 2 * m[i] + m[i+z] )
+     * 
+     *  Where i-x is the neighbour in the -x direction. This is similar 
+     *  for my and mz.
+     *  We can notice that the sum is the same if we do:
+     *        ( m[i-x] - m[i] ) + ( m[i+x] - m[i] )
+     *  so we can iterate through the neighbours and perform the sum with the
+     *  corresponding coefficient 1 /dx, 1/dy or 1/dz
+     *
+     *  The *m array contains the spins as:
+     *      [mx0, my0, mz0, mx1, my1, mz1, mx2, ...]
+     *  so if we want the starting position of the magnetisation for the
+     *  i-th spin, we only have to do (3 * i) for mx, (3 * i + 1) for my
+     *  and (3 * i + 2) for mz
+     *
+     */
+
+    /* Define the coefficients */
 	double ax = 2 * A / (dx * dx);
     double ay = 2 * A / (dy * dy);
     double az = 2 * A / (dz * dz);
 
+    /* Here we iterate through every mesh node */
 	#pragma omp parallel for
 	for (int i = 0; i < nxyz; i++) {
 	    double fx = 0, fy = 0, fz = 0;
-	    int idm = 0;
+	    int idm = 0;     // Index for the magnetisation matrix
 	    int idn = 6 * i; // index for the neighbours
 
+        /* Set a zero field for sites without magnetic material */
 	    if (Ms_inv[i] == 0.0){
 	        field[3 * i] = 0;
 	        field[3 * i + 1] = 0;
 	        field[3 * i + 2] = 0;
 	        continue;
 	    }
-
+        
+        /* Here we iterate through the neighbours */
         for (int j = 0; j < 6; j++) {
+            /* Remember that index=-1 is for sites without material */
 	        if (ngbs[idn + j] >= 0) {
-	            idm = 3 * ngbs[idn + j];
+                /* Magnetisation of the neighbouring spin since ngbs gives
+                 * the neighbour's index */
+	            idnm = 3 * ngbs[idn + j];
                 // if (Ms_inv[i] > 0){
-
+                
+                /* Neighbours in the -x and +x directions 
+                 * giving: ( m[i-x] - m[i] ) + ( m[i+x] - m[i] )
+                 * when ngbs[idn + j] > 0 for j = 0 and j=1
+                 * but there is a problem if, for example, there is no
+                 * neighbour at -x (j=0) in the 0th node (no PBCs),
+                 * thus, the second derivative would only be avaluated as:
+                 *      (1 / dx * dx) * ( m[i+x] - m[i] )
+                 * which is a wrong approximation (!) --> ASK about this
+                 */
                 if (j == 0 || j == 1) {
-                    fx += ax * (m[idm]     - m[3 * i]);
-                    fy += ax * (m[idm + 1] - m[3 * i + 1]);
-                    fz += ax * (m[idm + 2] - m[3 * i + 2]);
+                    fx += ax * (m[idnm]     - m[3 * i]);
+                    fy += ax * (m[idnm + 1] - m[3 * i + 1]);
+                    fz += ax * (m[idnm + 2] - m[3 * i + 2]);
                 }
-
+                /* Neighbours in the -y and +y directions */
                 else if (j == 2 || j == 3) {
-                    fx += ay * (m[idm]     - m[3  * i]);
-                    fy += ay * (m[idm + 1] - m[3 * i + 1]);
-                    fz += ay * (m[idm + 2] - m[3 * i + 2]);
+                    fx += ay * (m[idnm]     - m[3  * i]);
+                    fy += ay * (m[idnm + 1] - m[3 * i + 1]);
+                    fz += ay * (m[idnm + 2] - m[3 * i + 2]);
                 }
-
+                /* Neighbours in the -z and +z directions */
                 else if (j == 4 || j == 5) {
-                    fx += az * (m[idm]     - m[3 * i]);
-                    fy += az * (m[idm + 1] - m[3 * i + 1]);
-                    fz += az * (m[idm + 2] - m[3 * i + 2]);
+                    fx += az * (m[idnm]     - m[3 * i]);
+                    fy += az * (m[idnm + 1] - m[3 * i + 1]);
+                    fz += az * (m[idnm + 2] - m[3 * i + 2]);
                 }
-
                 else {
                     printf("Passing");
                     continue; }
@@ -51,11 +133,11 @@ void compute_exch_field_micro(double *m, double *field, double *energy,
             }
         }
 
+        /* Energy as: (A * mu0 * Ms / 2) * [ H_ex * m ]   */
         energy[i] = -0.5 * (fx * m[3 * i] + fy * m[3 * i + 1]
                             + fz * m[3 * i + 2]);
 
-        // printf("energy=%f", energy[i]);
-
+        /* Update the field H_ex which has the same structure than *m */
         field[3 * i]     = fx * Ms_inv[i] * MU0_INV;
         field[3 * i + 1] = fy * Ms_inv[i] * MU0_INV;
         field[3 * i + 2] = fz * Ms_inv[i] * MU0_INV;

--- a/fidimag/micro/lib/micro_clib.h
+++ b/fidimag/micro/lib/micro_clib.h
@@ -11,7 +11,7 @@ inline double cross_y(double a0, double a1, double a2, double b0, double b1, dou
 inline double cross_z(double a0, double a1, double a2, double b0, double b1, double b2) { return a0*b1 - a1*b0; }
 
 void compute_exch_field_micro(double *m, double *field, double *energy, double *Ms_inv,
-                         double A, double dx, double dy, double dz, int nx, int ny, int nz, int xperiodic, int yperiodic, int zperiodic);
+                         double A, double dx, double dy, double dz, int nxyz, int *ngbs);
 
 void dmi_field_bulk(double *m, double *field, double *energy, double *Ms_inv,
                     double *D, double dx, double dy, double dz,

--- a/fidimag/micro/lib/micro_clib.pyx
+++ b/fidimag/micro/lib/micro_clib.pyx
@@ -5,7 +5,7 @@ np.import_array()
 cdef extern from "micro_clib.h":
     void compute_exch_field_micro(double *m, double *field, double *energy, double *Ms_inv,
                           double A, double dx, double dy, double dz,
-                          int nx, int ny, int nz, int xperiodic, int yperiodic, int zperiodic)
+                          int nxyz, int *ngbs)
     void dmi_field_bulk(double *m, double *field, double *energy, double *Ms_inv, double *D, double dx, double dy, double dz, 
                         int nx, int ny, int nz, int xperiodic, int yperiodic, int zperiodic)
 
@@ -21,10 +21,10 @@ def compute_exchange_field_micro(np.ndarray[double, ndim=1, mode="c"] m,
                             np.ndarray[double, ndim=1, mode="c"] field,
                             np.ndarray[double, ndim=1, mode="c"] energy,
                             np.ndarray[double, ndim=1, mode="c"] Ms_inv,
-                            A, dx, dy, dz, nx, ny, nz,
-                            xperiodic, yperiodic, zperiodic):
+                            A, dx, dy, dz, nxyz,
+            		    np.ndarray[int, ndim=2, mode="c"] ngbs):
 
-    compute_exch_field_micro(&m[0], &field[0], &energy[0], &Ms_inv[0], A, dx, dy, dz, nx, ny, nz, xperiodic, yperiodic, zperiodic)
+    compute_exch_field_micro(&m[0], &field[0], &energy[0], &Ms_inv[0], A, dx, dy, dz, nxyz, &ngbs[0, 0])
     
 
 def compute_dmi_field_bulk(np.ndarray[double, ndim=1, mode="c"] m,

--- a/fidimag/micro/mesh.py
+++ b/fidimag/micro/mesh.py
@@ -71,9 +71,41 @@ class FDMesh():
 
                     self.pos.append(tp)
 
+
     def index(self, i, j, k):
-        idx = k * self.nxy + j * self.nx + i
-        return idx
+        """
+        Returns the index for the cell with ordinals i, j, k
+        or False if that cell would be out of bounds. Handles periodic meshes.
+        """
+        if self.xperiodic:  # if mesh is periodic in x-direction
+            if i <= -1:          # then wrap the left side
+                i = self.nx - 1  # to the right
+            if i >= self.nx:     # and wrap the right side
+                i = 0            # to the left
+
+        if self.yperiodic:
+            if j <= -1:
+                j = self.ny - 1
+            if j >= self.ny:
+                j = 0
+
+        if self.zperiodic:
+            if k <= -1:
+                k = self.nz - 1
+            if k >= self.nz:
+                k = 0
+
+        return self._index(i, j, k)
+
+    def _index(self, i, j, k):
+        """
+        Returns the index for the cell with ordinals i, j, k
+        or False if that cell would be out of bounds.
+
+        """
+        if i < 0 or j < 0 or k < 0 or i >= self.nx or j >= self.ny or k >= self.nz:
+            return -1
+        return k * self.nxy + j * self.nx + i
 
     def init_neighbours(self):
         """

--- a/fidimag/micro/omf.py
+++ b/fidimag/micro/omf.py
@@ -3,7 +3,7 @@
 import math
 import os
 import sys
-import numpy
+import numpy as np
 import struct
 
 
@@ -43,8 +43,8 @@ class OMF2:
 
         count = 3 * self.xnodes * self.ynodes * self.znodes
         data = f.read(8 * count)
-        self.data = numpy.frombuffer(data)
-        self.data = numpy.reshape(self.data, (-1, 3))
+        self.data = np.frombuffer(data)
+        self.data = np.reshape(self.data, (-1, 3))
         f.close()
         return
 
@@ -61,15 +61,22 @@ class OMF2:
 
     def get_all_mag(self, comp='x'):
         """
-        return x, y or z component of magnetisation of all nodes 
+        return x, y or z component of magnetisation of all nodes
         """
         index = ord(comp) - ord('x')
-        return self.data[:,index]
-	
+        return self.data[:, index]
+
     def get_all_mags(self, order='xyz'):
-        if order=='xyz':
+        """
+        Return the x, y AND z components of the magnetisation
+        field for every node as a numpy array
+        """
+        if order == 'xyz':
             d = self.data.copy()
-            d.shape=(-1)
+            d.shape = (-1)
             return d
-        elif order=='xxx':
-            return np.array([self.data[:,0], self.data[:,1], self.data[:,2]])
+
+        elif order == 'xxx':
+            return np.array([self.data[:, 0],
+                             self.data[:, 1],
+                             self.data[:, 2]])

--- a/tests/test_exch_micro.py
+++ b/tests/test_exch_micro.py
@@ -1,3 +1,40 @@
+"""
+Test of the micromagnetic exchange field using an analytical
+expression.
+
+The system is a 1D mesh of 100 spins: FDMesh(nx=100, ny=1, nz=1)
+which are located at positions starting at 0.5 since the default
+mesh spacing is dx=1, thus we have something like:
+
+           dx=1
+          o -- o -- o -- o -- o --
+x    =   0.5  1.5  2.5  3.5  ...
+i    =    0    1    2    3
+
+The **init_m** function will set the magnetisation as:
+    mx = 0, my = sin(n_x) , mz = cos(n_x)
+
+where n_x is ( k * (x - 0.5) ), with x the position
+of the i-th spin, therefore the values in the mesh are:
+
+                o -- o -- o -- o -- o --
+x   - 0.5  =    0    1    2    3   ...
+n_x        =    0   0.1  0.2  0.3
+
+For the **test_exch_1d**, we set A = 1, Ms = 1 / mu0, hence
+the exchange field H_ex will be:
+
+    H_ex = (2 A / (mu0 * Ms)) * nabla^2 (mx, my, mz)
+         = 2 * (Dx^2 mx, Dx^2 my, Dx^2 mz)
+         = -2 * (k ^ 2) * (0, sin(n_x), cos(n_x)
+
+where we used Dx^2 = d^2 / dx^2. Remember that
+sin(n_x) = sin(k * (x - 0.5)).
+
+With this expression, we compare the Fidimag computed value.
+
+"""
+
 import matplotlib as mpl
 mpl.use("Agg")
 import matplotlib.pyplot as plt
@@ -7,54 +44,79 @@ from fidimag.micro import FDMesh, UniformExchange, Sim
 
 
 def init_m(pos):
+    """
+    The initial magnetisation function defined in the
+    introduction
+    """
     x, y, z = pos
 
-    k =  0.1
-
-    nx = k*(x-0.5)
+    k = 0.1
+    nx = k * (x - 0.5)
 
     return (0, np.sin(nx), np.cos(nx))
 
+
 def test_init():
+    """
+    This tests (mx, my, mx) for the first 2 spins
+    """
     mesh = FDMesh(nx=100, ny=1, nz=1)
     sim = Sim(mesh)
     sim.set_m(init_m)
 
-    expected=np.array([0,0,1, 0, np.sin(0.1), np.cos(0.1)])
+    expected = np.array([0, 0, 1,
+                         0, np.sin(0.1), np.cos(0.1)])
 
-    assert max(abs(sim.spin[:6]-expected))<1e-15
+    assert max(abs(sim.spin[:6] - expected)) < 1e-15
+
 
 def test_exch_1d(do_plot=False):
+    # Initiate the 1D mesh and magnetisation as before
     mesh = FDMesh(nx=100, ny=1, nz=1)
     sim = Sim(mesh)
     sim.set_m(init_m)
 
-    mu0 = 4*np.pi*1e-7
-    sim.Ms = 1.0/mu0
-    
+    # Simplify the magnetic parameters
+    mu0 = 4 * np.pi * 1e-7
+    sim.Ms = 1.0 / mu0
+
     exch = UniformExchange(1)
     sim.add(exch)
 
+    # Compute the exchange field and reshape it in order
+    # to leave every row as the [f_x, f_y, f_z] array
+    # for every spin
     field = exch.compute_field()
     field.shape = (-1, 3)
 
-    assert max(abs(field[:,0])) == 0
+    # We know that the field in x is always zero ( see the
+    # analytical calculation at the beginning)
+    assert max(abs(field[:, 0])) == 0
 
+    # These are the analytical values for the exchange field in y,z
+    # In this case, k=0.1 , then 2 * k^2 evaluates as 0.02
     xs = np.linspace(0, 99, 100)
-    epy = -0.02*np.sin(0.1*xs)
-    epz = -0.02*np.cos(0.1*xs)
+    epy = -0.02 * np.sin(0.1 * xs)
+    epz = -0.02 * np.cos(0.1 * xs)
 
-    assert max(abs(epy[1:-1] - field[1, 1:-1]))<3e-5
+    # Compare the analytical value
+    # of the y component of the exchange field, with Fidimag's
+    # result (second column of the reshaped field array)
+
+    # WARNING: NOTICE that we are not considering the extremes since
+    # there is a wrong expression in the border of the exchange field
+    # with NO PBCs. We must FIX this test!
+    assert max(abs(epy[1:-1] - field[1:-1, 1])) < 3e-5
 
     if do_plot:
-        plt.plot(xs, field[:,1], "-.", label="my", color='DarkGreen')
-        plt.plot(xs, field[:,2], "-.", label="mz", color='DarkGreen')
+        plt.plot(xs, field[:, 1], "-.", label="my", color='DarkGreen')
+        plt.plot(xs, field[:, 2], "-.", label="mz", color='DarkGreen')
         plt.plot(xs, epy, "--", label="analytical", color='b')
         plt.plot(xs, epz, "--", color='r')
         plt.xlabel("xs")
         plt.ylabel("field")
         plt.legend()
-        plt.savefig("exchange_field.pdf") 
+        plt.savefig("exchange_field.pdf")
 
 if __name__ == '__main__':
     test_init()

--- a/tests/test_exch_micro.py
+++ b/tests/test_exch_micro.py
@@ -44,7 +44,7 @@ def test_exch_1d(do_plot=False):
     epy = -0.02*np.sin(0.1*xs)
     epz = -0.02*np.cos(0.1*xs)
 
-    assert max(abs(epy[1:-1] - field[1:-1,1]))<3e-5
+    assert max(abs(epy[1:-1] - field[1, 1:-1]))<3e-5
 
     if do_plot:
         plt.plot(xs, field[:,1], "-.", label="my", color='DarkGreen')

--- a/tests/test_oommf.py
+++ b/tests/test_oommf.py
@@ -146,6 +146,7 @@ def test_with_oommf_spatial_Ms(A=1e-11):
     field_oommf = compute_exch_field(
         mesh, init_m0=init_m0, A=A, spatial_Ms=init_Ms)
     mx0, mx1, mx2 = compare_fields(field_oommf, field)
+
     assert max([mx0, mx1, mx2]) < 1e-12
 
     field = demag.compute_field()
@@ -264,16 +265,17 @@ def test_demag_field_oommf_large(Ms=8e5, A=1.3e-11):
 
     #exact = demag.compute_exact()
 
-    init_m0 = """
-    return [list [expr {sin($x*1e9)+$y*1e9+$z*2.3e9}] [expr {cos($x*1e9)+$y*1e9+$z*1.3e9}] 0]
-    """
+    init_m0 = (r'return [list [expr {sin($x * 1e9) + $y * 1e9 + $z * 2.3e9}] '
+               + r' [expr {cos($x * 1e9) + $y * 1e9 + $z * 1.3e9}] '
+               + r'0 '
+               + r'] ')
 
     demag_oommf = compute_demag_field(mesh, Ms=Ms, init_m0=init_m0)
     exch_oommf = compute_exch_field(mesh, Ms=Ms, init_m0=init_m0, A=A)
 
     mx0, mx1, mx2 = compare_fields(demag_oommf, demag_field)
     #print mx0, mx1, mx2
-    assert max([mx0,mx1,mx2])< 5e-10
+    assert max([mx0, mx1, mx2]) < 5e-10
 
     mx0, mx1, mx2 = compare_fields(exch_oommf, exch_field)
     #print mx0, mx1, mx2

--- a/tests/test_oommf_without_run.py
+++ b/tests/test_oommf_without_run.py
@@ -56,7 +56,10 @@ def test_exch_field_oommf(A=1e-11, Ms=2.6e5):
     init_m0 = """
     return [list [expr {sin($x*1e9)+$y*1e9+$z*2.3e9}] [expr {cos($x*1e9)+$y*1e9+$z*1.3e9}] 0]
     """
-    omf_file = os.path.join(os.path.dirname(os.path.abspath(__file__)),'omfs','test_exch_field_oommf.ohf')
+    omf_file = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                            'omfs',
+                            'test_exch_field_oommf.ohf'
+                            )
     ovf = OMF2(omf_file)
     field_oommf = ovf.get_all_mags()
 


### PR DESCRIPTION
Simplified the Exchange calculation in C file. This follows the same technique than in OOMMf, where the calculation error is of order O(h^2) (h is mesh spacing). Massively documented the file and some OOMMF tests.