### PR TITLE
Trial for using Miniconda on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ before_script:
         - export LD_LIBRARY_PATH="/home/travis/build/fangohr/fidimag/local/lib:$LD_LIBRARY_PATH"
         - export LD_RUN_PATH="/home/travis/build/fangohr/fidimag/local/lib:$LD_RUN_PATH"
         - export OMP_NUM_THREADS=1
+        - export MPLBACKEND=Agg
 
 # command to run tests
 # tvtk can't be imported without an X server, so we run in xvfb, which creates a virtual display

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_install:
   - sudo apt-get install xvfb
 
 install:
-  - conda create -y -n fidimag-test cython matplotlib pytest mayavi wxpython
+  - conda create -y -n fidimag-test cython matplotlib pytest mayavi
   - source activate fidimag-test
   # Download and compile FFTW & Sundials locally
   - bash bin/install.sh
@@ -24,7 +24,8 @@ before_script:
         - export LD_RUN_PATH="/home/travis/build/fangohr/fidimag/local/lib:$LD_RUN_PATH"
         - export OMP_NUM_THREADS=1
         - export MPLBACKEND=Agg
-        - export ETS_TOOLKIT=wx
+        # Tells matplotlib (?) to use PyQt class v2 APIs (I think)
+        - export QT_API=pyqt
 
 # command to run tests
 # tvtk can't be imported without an X server, so we run in xvfb, which creates a virtual display

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ python:
         - "2.7"
 # command to install dependencies
 before_install:
-  - wget http://repo.continuum.io/miniconda/Miniconda-2.2.2-Linux-x86_64.sh -O miniconda.sh
+  - wget http://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh
   - chmod +x miniconda.sh
   - ./miniconda.sh -b
   - export PATH=/home/travis/anaconda/bin:$PATH

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,30 +3,27 @@ python:
         - "2.7"
 # command to install dependencies
 before_install:
-        # libfftw in ubuntu 12.04 is a bit older for fidimag.
-        # - sudo apt-get install libsundials-serial-dev libfftw3-dev
-        # Matplotlib installation using apt-get is failing
-        - sudo apt-get update
-        - sudo apt-get install mayavi2 xvfb
+  - wget http://repo.continuum.io/miniconda/Miniconda-2.2.2-Linux-x86_64.sh -O miniconda.sh
+  - chmod +x miniconda.sh
+  - ./miniconda.sh -b
+  - export PATH=/home/travis/miniconda/bin:$PATH
+  # XVFB for running tests in virtual X display
+  - sudo apt-get update
+  - sudo apt-get install xvfb
 
 install:
+  - conda install cython matplotlib
+  - conda install -c http://conda.anaconda.org/moble fftw
+  - conda install -c http://conda.anaconda.org/chemreac sundials
         - pip install cython
         - pip install matplotlib
-        - pip install pyvtk
-        # - pip install Mayavi[app] --> Needs VTK
 
 before_script:
-        - bash bin/install.sh
         - make build
         - export PYTHONPATH="/home/travis/build/fangohr/fidimag:$PYTHONPATH"
-        - export LD_LIBRARY_PATH="/home/travis/build/fangohr/fidimag/local/lib:$LD_LIBRARY_PATH"
-        - export LD_RUN_PATH="/home/travis/build/fangohr/fidimag/local/lib:$LD_RUN_PATH"
         - export OMP_NUM_THREADS=1
-
-virtualenv:
-    system_site_packages: true
 
 # command to run tests
 # tvtk can't be imported without an X server, so we run in xvfb, which creates a virtual display
 script:
-        - xvfb-run --server-args="-screen 0 1024x768x24" make test-without-run-oommf
+  - xvfb-run --server-args="-screen 0 1024x768x24" make test-without-run-oommf

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_install:
   - sudo apt-get install xvfb
 
 install:
-  - conda create -y -n fidimag-test cython matplotlib pytest
+  - conda create -y -n fidimag-test cython matplotlib pytest mayavi
   - source activate fidimag-test
   # Download and compile FFTW & Sundials locally
   - bash bin/install.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ before_install:
   - wget http://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh
   - chmod +x miniconda.sh
   - ./miniconda.sh -b
-  - export PATH=/home/travis/anaconda/bin:$PATH
+  - export PATH=/home/travis/miniconda2/bin:$PATH
   # XVFB for running tests in virtual X display
   - sudo apt-get update
   - sudo apt-get install xvfb

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,8 @@ before_install:
   - sudo apt-get install xvfb
 
 install:
-  - conda install -y cython matplotlib
+  - conda create -y -n fidimag-test cython matplotlib
+  - source activate fidimag-test
   - conda install -y -c http://conda.anaconda.org/moble fftw
   - conda install -y -c http://conda.anaconda.org/chemreac sundials
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_install:
   - sudo apt-get install xvfb
 
 install:
-  - conda create -y -n fidimag-test cython matplotlib pytest mayavi
+  - conda create -y -n fidimag-test cython matplotlib pytest mayavi wxpython
   - source activate fidimag-test
   # Download and compile FFTW & Sundials locally
   - bash bin/install.sh
@@ -24,6 +24,7 @@ before_script:
         - export LD_RUN_PATH="/home/travis/build/fangohr/fidimag/local/lib:$LD_RUN_PATH"
         - export OMP_NUM_THREADS=1
         - export MPLBACKEND=Agg
+        - export ETS_TOOLKIT=wx
 
 # command to run tests
 # tvtk can't be imported without an X server, so we run in xvfb, which creates a virtual display

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,12 +14,14 @@ before_install:
 install:
   - conda create -y -n fidimag-test cython matplotlib
   - source activate fidimag-test
-  - conda install -y -c http://conda.anaconda.org/moble fftw
-  - conda install -y -c http://conda.anaconda.org/chemreac sundials
+  # Download and compile FFTW & Sundials locally
+  - bash bin/install.sh
 
 before_script:
         - make build
         - export PYTHONPATH="/home/travis/build/fangohr/fidimag:$PYTHONPATH"
+        - export LD_LIBRARY_PATH="/home/travis/build/fangohr/fidimag/local/lib:$LD_LIBRARY_PATH"
+        - export LD_RUN_PATH="/home/travis/build/fangohr/fidimag/local/lib:$LD_RUN_PATH"
         - export OMP_NUM_THREADS=1
 
 # command to run tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ before_install:
   - wget http://repo.continuum.io/miniconda/Miniconda-2.2.2-Linux-x86_64.sh -O miniconda.sh
   - chmod +x miniconda.sh
   - ./miniconda.sh -b
-  - export PATH=/home/travis/miniconda/bin:$PATH
+  - export PATH=/home/travis/anaconda/bin:$PATH
   # XVFB for running tests in virtual X display
   - sudo apt-get update
   - sudo apt-get install xvfb

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_install:
   - sudo apt-get install xvfb
 
 install:
-  - conda create -y -n fidimag-test cython matplotlib
+  - conda create -y -n fidimag-test cython matplotlib pytest
   - source activate fidimag-test
   # Download and compile FFTW & Sundials locally
   - bash bin/install.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,11 +12,9 @@ before_install:
   - sudo apt-get install xvfb
 
 install:
-  - conda install cython matplotlib
-  - conda install -c http://conda.anaconda.org/moble fftw
-  - conda install -c http://conda.anaconda.org/chemreac sundials
-        - pip install cython
-        - pip install matplotlib
+  - conda install -y cython matplotlib
+  - conda install -y -c http://conda.anaconda.org/moble fftw
+  - conda install -y -c http://conda.anaconda.org/chemreac sundials
 
 before_script:
         - make build


### PR DESCRIPTION
Should speed up test runs quite a bit if it works. It currently relies on random third party packages for FFTW and Sundials;  if you use this, you might want to build your own packages so you can update them as needed.